### PR TITLE
Register access token providers with scoped lifetimes

### DIFF
--- a/src/Authentication/OAuth/AccessTokenProviderBuilderExtensions.cs
+++ b/src/Authentication/OAuth/AccessTokenProviderBuilderExtensions.cs
@@ -101,7 +101,7 @@ public static class AccessTokenProviderBuilderExtensions
     public static IAccessTokenProviderBuilder UseCustomProvider(this IAccessTokenProviderBuilder builder,
         IAccessTokenProvider provider)
     {
-        builder.Services.AddTransient(_ => provider);
+        builder.Services.AddScoped(_ => provider);
 
         return builder;
     }
@@ -114,7 +114,7 @@ public static class AccessTokenProviderBuilderExtensions
     public static IAccessTokenProviderBuilder UseCustomProvider<TProvider>(this IAccessTokenProviderBuilder builder)
         where TProvider : class, IAccessTokenProvider
     {
-        builder.Services.AddTransient<IAccessTokenProvider, TProvider>();
+        builder.Services.AddScoped<IAccessTokenProvider, TProvider>();
 
         return builder;
     }
@@ -129,7 +129,7 @@ public static class AccessTokenProviderBuilderExtensions
         Func<IServiceProvider, TProvider> implementationFactory)
         where TProvider : class, IAccessTokenProvider
     {
-        builder.Services.AddTransient<IAccessTokenProvider>(implementationFactory);
+        builder.Services.AddScoped<IAccessTokenProvider>(implementationFactory);
 
         return builder;
     }

--- a/src/Authentication/OAuth/DistributedCachingAccessTokenProvider.cs
+++ b/src/Authentication/OAuth/DistributedCachingAccessTokenProvider.cs
@@ -5,8 +5,8 @@ using Microsoft.Extensions.Options;
 namespace Hexagrams.Extensions.Authentication.OAuth;
 
 /// <summary>
-/// An <see cref="IAccessTokenProvider" /> decorator that caches access token responses in an
-/// <see cref="IDistributedCache" />.
+/// A decorator for <see cref="IAccessTokenProvider" /> decorator that caches access token responses using an instance
+/// of <see cref="IDistributedCache" />.
 /// </summary>
 public class DistributedCachingAccessTokenProvider : IAccessTokenProvider
 {


### PR DESCRIPTION
This should yield the same behaviour as transient when necessary, while also covering situations where scoped lifetimes are required.