### PR TITLE
Accept an optional message parameter when requiring configuration keys

### DIFF
--- a/src/Configuration/ConfigurationExtensions.cs
+++ b/src/Configuration/ConfigurationExtensions.cs
@@ -12,16 +12,19 @@ public static class ConfigurationExtensions
     /// </summary>
     /// <param name="config">The configuration.</param>
     /// <param name="key">The configuration key.</param>
+    /// <param name="exceptionMessage">A custom message for when no value is found for the configuration key.</param>
     /// <returns>The configuration value.</returns>
     /// <exception cref="ConfigurationException">The configuration value is not found or is whitespace.</exception>
-    public static string Require(this IConfiguration config, string key)
+    public static string Require(this IConfiguration config, string key, string? exceptionMessage = null)
     {
         var value = config[key];
 
-        if (string.IsNullOrWhiteSpace(value))
-            throw new ConfigurationException($"No value found for configuration key {key}");
+        if (!string.IsNullOrWhiteSpace(value))
+            return value;
 
-        return value;
+        var message = exceptionMessage ?? $"No value found for configuration key {key}";
+
+        throw new ConfigurationException(message);
     }
 
     /// <summary>
@@ -31,18 +34,21 @@ public static class ConfigurationExtensions
     /// <typeparam name="TValue">The type to convert the value to.</typeparam>
     /// <param name="config">The configuration.</param>
     /// <param name="key">The configuration key.</param>
+    /// <param name="exceptionMessage">A custom message for when no value is found for the configuration key.</param>
     /// <returns>The configuration value.</returns>
     /// <exception cref="ConfigurationException">
     /// The configuration value is not found or is not convertible to <typeparamref name="TValue"/>.
     /// </exception>
-    public static TValue Require<TValue>(this IConfiguration config, string key)
+    public static TValue Require<TValue>(this IConfiguration config, string key, string? exceptionMessage = null)
     {
         var value = config.GetValue(typeof(TValue), key, null);
 
-        if (value is not TValue typedValue)
-            throw new ConfigurationException($"No value found for configuration key {key}");
+        if (value is TValue typedValue)
+            return typedValue;
 
-        return typedValue;
+        var message = exceptionMessage ?? $"No value found for configuration key {key}";
+
+        throw new ConfigurationException(message);
     }
 
     /// <summary>

--- a/tests/Configuration/ConfigurationExtensionsTests.cs
+++ b/tests/Configuration/ConfigurationExtensionsTests.cs
@@ -33,6 +33,23 @@ public class ConfigurationExtensionsTests
         test.Should().Throw<ConfigurationException>().WithMessage($"*{key}*");
     }
 
+    [Fact]
+    public void Require_throws_configuration_exception_with_supplied_message_when_key_is_not_found()
+    {
+        const string key = "foo";
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { { "bar", "baz" } })
+            .Build();
+
+        const string expectedMessage = "Oopsie woopsie!";
+
+        var test = () => config.Require(key, expectedMessage);
+
+        test.Should().Throw<ConfigurationException>()
+            .WithMessage(expectedMessage);
+    }
+
     [Theory]
     [InlineData((string?) null)]
     [InlineData("")]
@@ -97,6 +114,21 @@ public class ConfigurationExtensionsTests
         var test = () => config.Require<Guid>(key);
 
         test.Should().Throw<ConfigurationException>().WithMessage($"*{key}*");
+    }
+    [Fact]
+    public void Require_T_throws_exception_with_supplied_message_when_key_is_not_found()
+    {
+        const string key = "foo";
+
+        var config = new ConfigurationBuilder()
+            .Build();
+
+        const string expectedMessage = "Oopsie woopsie!";
+
+        var test = () => config.Require(key, expectedMessage);
+
+        test.Should().Throw<ConfigurationException>()
+            .WithMessage(expectedMessage);
     }
 
     [Fact]


### PR DESCRIPTION
Adds an optional parameter to specify the message of the resulting `ConfigurationException` when a configuration key is not found by the `.Require()` and `.Require<T>()` configuration extension methods.